### PR TITLE
Method exposing all section names

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -31,6 +31,15 @@ type File map[string]Section
 // A Section represents a single section of an INI file.
 type Section map[string]string
 
+// Returns a slice containing all section names.
+func (f File) Sections() (secs[]string) {
+	secs = make([]string, 0, len(f))
+	for k := range f {
+		secs = append(secs, k)
+	}
+	return
+}
+
 // Returns a named Section. A Section will be created if one does not already exist for the given name.
 func (f File) Section(name string) Section {
 	section := f[name]

--- a/ini_test.go
+++ b/ini_test.go
@@ -2,6 +2,7 @@ package ini
 
 import (
 	"strings"
+	"sort"
 	"testing"
 )
 
@@ -25,12 +26,26 @@ func TestLoad(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	sections := file.Sections()
+	sort.Strings(sections)
+	expected := []string{
+		"",
+		"bar",
+		"foo",
+	}
+	sort.Strings(expected)
+	for i := range expected {
+		if expected[i] != sections[i] {
+			t.Errorf("section mismatch: %q %q", expected[i], sections[i])
+		}
+	}
+
 	check := func(section, key, expect string) {
 		if value, _ := file.Get(section, key); value != expect {
 			t.Errorf("Get(%q, %q): expected %q, got %q", section, key, expect, value)
 		}
 	}
-
 	check("", "herp", "derp")
 	check("foo", "hello", "world")
 	check("foo", "whitespace should", "not matter")


### PR DESCRIPTION
While the section names could be extracted from the fact that a `File`
is of type `map[string]Section`, I don't think that implementor should
expect that. Instead, I've created a method that returns the section so
that they can be iterated over in a future-proof fashion.
