### PR TITLE
Example of iterating through sections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ for key, value := range file.Section("mysection") {
 }
 ```
 
+Iterate through sections in a file:
+
+```go
+for sectionName, section := range file {
+  fmt.Printf("Section name: %s", sectionName)
+}
+```
+Note that the current implementation always includes the empty section
+when iterating.
+
 File Format
 -----------
 


### PR DESCRIPTION
This was discussed in #1.

I also made a note about the fact that the empty section always existing. Not sure if that is a bug (when it does not contain any keys) or not.
