### PR TITLE
Join lines ending with backslash

### DIFF
--- a/ini_test.go
+++ b/ini_test.go
@@ -87,3 +87,28 @@ func TestDefinedSectionBehaviour(t *testing.T) {
 		"a": {"this": "that"},
 	})
 }
+
+func TestEscapeNewline(t *testing.T) {
+	// There is no space after the \ behind 'some'
+	// There is a space after the \ behind 'long'
+	src := `
+	[sectionname]
+	key = some \
+			 really long \ 
+			 value
+	something = else`
+
+	file, err := Load(strings.NewReader(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	check := func(section, key, expect string) {
+		if value, _ := file.Get(section, key); value != expect {
+			t.Errorf("Get(%q, %q): expected %q, got %q", section, key, expect, value)
+		}
+	}
+
+	check("sectionname", "key", "some really long value")
+	check("sectionname", "something", "else")
+}


### PR DESCRIPTION
OfflineIMAP allows one to enter lambda functions to map remote names and local names (among others); unfortunately they end up spawning many lines. Here's a part of my config file:

``` python
nametrans = lambda folder : folder == 'archive' and '[Gmail]/All Mail' \
                         or folder == 'inbox' and 'INBOX' \
                         or folder == 'spam' and '[Gmail]/Spam' \
                         or folder == 'trash' and '[Gmail]/Trash' \
                         or folder == 'drafts' and '[Gmail]/Drafts' \
                         or folder == 'starred' and '[Gmail]/Starred' \
                         or folder == 'sent' and '[Gmail]/Sent Mail' \
                         or folder
```

This PR makes sure the file is parsed correctly and the `nametrans` key has a correct value (ie the rest joined)
